### PR TITLE
add the platforms 'ebook' and 'comedy'

### DIFF
--- a/humblebundle.py
+++ b/humblebundle.py
@@ -745,7 +745,7 @@ def parseargs(args=None):
 
     default = "linux"
     parser.add_argument('--platform', '-p', dest='platform',
-                        default=default, choices=['windows', 'mac', 'linux', 'android', 'audio'],
+                        default=default, choices=['windows', 'mac', 'linux', 'android', 'audio', 'ebook', 'comedy'],
                         help="Download platform. Default is '%s'" % default)
 
     parser.add_argument('--bittorrent', '-b', dest='bittorrent', default=False, action="store_true",


### PR DESCRIPTION
I actually only needed the 'ebook' one, but according to the page source there's also 'comedy'
