### PR TITLE
Fixes wrong MD5 when downloading torrent file.

### DIFF
--- a/humblebundle.py
+++ b/humblebundle.py
@@ -278,7 +278,10 @@ class HumbleBundle(httpbot.HttpBot):
                                   type_pref=type_pref, arch_pref=arch_pref)
         if not d:
             return
-
+        if bittorrent: d['md5'] = None #md5 belongs not to .torrent file!
+        if d['md5']: d['md5'].lower()
+        md5 = d.get('md5', '')
+        
         url = d['url'].get('bittorrent' if bittorrent else 'web','')
         if not url:
             log.error("Selected download has no URL")
@@ -314,8 +317,7 @@ class HumbleBundle(httpbot.HttpBot):
         print "Downloading '%s' [%s]\t%s" % (
             game['human_name'], game['machine_name'], self._download_info(d))
         try:
-            return super(HumbleBundle, self).download(url, path,
-                                                      d.get('md5', '').lower())
+            return super(HumbleBundle, self).download(url, path, md5)
         except httpbot.urllib2.HTTPError as e:
             # Unauthorized (most likely outdated download URL) or something else?
             if not e.code == 403:


### PR DESCRIPTION
Implements a workaround (do not check MD5 when downloading a torrent
file) to avoid a misleading error message and a wrong exit status when
using -b with --download. The problem is caused by the humble bundle
API, which gives an MD5 not for the torrent file, but the normal
download. Since the integrity of a Bittorrent download is ensured by the
Bittorrent protocol, this MD5 is not useful here. So the workaround is
to set the MD5 to None when using -b. Unfortunately, this way, the
integrity of the .torrent file can not be ensured.

In case you have suggestions for a better solution or a better style, please tell me. This was just a fast fix, fitting my needs.
