### PR TITLE
Will not run on Debian without python-xdg

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Dependencies
 
 The above can be installed in any modern Debian-like distros (like Ubuntu/Mint) with:
 
-	sudo apt-get install python-{lxml,progressbar,keyring}
+	sudo apt-get install python-{lxml,progressbar,keyring,xdg}
 
 
 Install


### PR DESCRIPTION
This will not run on Debian without python-xdg or you will receive "ImportError: No module named xdg.BaseDirectory"
