### PR TITLE
Fix empty string in use of keyring

### DIFF
--- a/humblebundle.py
+++ b/humblebundle.py
@@ -826,7 +826,7 @@ def read_config(args, appname=None, configdir=None):
     if keyring:
         log.debug("Reading credentials from keyring")
         try:
-            username, password = (keyring.get_password(appname, '').split('\n') +
+            username, password = (keyring.get_password(appname, 'humble').split('\n') +
                                   ['\n'])[:2]
         except AttributeError as e:
             log.warn("Credentials not found in keyring. First time usage?")
@@ -847,7 +847,7 @@ def read_config(args, appname=None, configdir=None):
     if args.username or args.password:
         log.info("Saving credentials")
         if keyring:
-            keyring.set_password(appname, '',
+            keyring.set_password(appname, 'humble',
                                  '%s\n%s' % (args.username or username,
                                              args.password or password,))
         else:


### PR DESCRIPTION
This change fixes saving/loading credentials for me. Otherwise I get
`2016-08-24 19:56:24,918 CRITICAL        File contains parsing errors: /home/sec/.local/share/python_keyring/keyring_pass.cfg
`
