### PR TITLE
update URL for python-keyring-lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Dependencies
 
 - [lxml](http://lxml.de)
 - [Progressbar](https://code.google.com/p/python-progressbar)
-- [Python Keyring Lib](https://bitbucket.org/kang/python-keyring-lib)
+- [Python Keyring Lib](https://github.com/jaraco/keyring)
 - [PyXDG](https://freedesktop.org/wiki/Software/pyxdg/)
 
 The above can be installed in any modern Debian-like distros (like Ubuntu/Mint) with:


### PR DESCRIPTION
moved to https://github.com/jaraco/keyring