### PR TITLE
Don't add download to candidates if it's already been added.

### DIFF
--- a/humblebundle.py
+++ b/humblebundle.py
@@ -351,6 +351,8 @@ class HumbleBundle(httpbot.HttpBot):
         for plat in game.get('downloads', []):
             if plat.get('platform', '') == platform:
                 for download in plat.get('download_struct', []):
+                    if download in candidates:
+                        continue
                     if not download.get('url', ''):
                         continue
                     if (serverfile and


### PR DESCRIPTION
For some reason download_struct can contain duplicates. Maybe when a game
is in more than one bundle?

Skip this download if an exact copy is already  in candidates.