### PR TITLE
Fix for error during validation of the browser code

### DIFF
--- a/humblebundle.py
+++ b/humblebundle.py
@@ -126,12 +126,14 @@ class HumbleBundle(httpbot.HttpBot):
             log.info("Validating browser code at '%s/user/humbleguard'",
                      self.url)
             try:
+                # Load coockies in unlikely case that cookies.txt was not present
+                self.get("/")
                 token = None
                 for cookie in self.cookiejar:
                     if cookie.name == 'csrf_cookie':
                         token = cookie.value
                 if token is None:
-                    raise HumbleBundleError("No CSRF token. Execute one time without --code argument.")
+                    raise HumbleBundleError("Missing CSRF token")
                 self.get("/user/humbleguard",
                                {'goto': "/home",
                                 'qs'  : "",

--- a/humblebundle.py
+++ b/humblebundle.py
@@ -126,9 +126,16 @@ class HumbleBundle(httpbot.HttpBot):
             log.info("Validating browser code at '%s/user/humbleguard'",
                      self.url)
             try:
+                token = None
+                for cookie in self.cookiejar:
+                    if cookie.name == 'csrf_cookie':
+                        token = cookie.value
+                if token is None:
+                    raise HumbleBundleError("No CSRF token. Execute one time without --code argument.")
                 self.get("/user/humbleguard",
                                {'goto': "/home",
                                 'qs'  : "",
+                                '_le_csrf_token'  : token,
                                 'code': code.upper()})
             except httpbot.urllib2.HTTPError as e:
                 raise HumbleBundleError("Incorrect browser verification code")


### PR DESCRIPTION
Running `humblebundle --auth <auth> --code <code>` returns 401 error.

When calling `/user/humbleguard` by hand and inspecting the request in the browser an additional parameter is passed in the payload: `_le_csrf_token`

Adding this argument it to the `/user/humbleguard` request allows me to login and list my games.

The second commit adds a load of the main page to make sure that CSRF cookie is present in the cookiejar. I think it should not hurt and will cover a corner case when someone calls `humblebundle` from the getgo with the `--code` argument.