### PR TITLE
Download option working in Python 3

### DIFF
--- a/httpbot.py
+++ b/httpbot.py
@@ -31,7 +31,7 @@ if sys.version_info.major < 3:
 else:
     import urllib.request as urllib2
     import urllib.parse as urlparse
-    urllib.unquote  = urllib.parse.unquote 
+    urllib.unquote  = urlparse.unquote 
     HTTPError       = urllib.error.HTTPError
 
 

--- a/httpbot.py
+++ b/httpbot.py
@@ -29,9 +29,10 @@ if sys.version_info.major < 3:
     import urlparse  # @UnresolvedImport
     HTTPError = urllib2.HTTPError
 else:
-    urllib2   = urllib.request          # @UndefinedVariable
-    urlparse  = urllib.parse            # @UndefinedVariable
-    HTTPError = urllib.error.HTTPError  # @UndefinedVariable
+    import urllib.request as urllib2
+    import urllib.parse as urlparse
+    urllib.unquote  = urllib.parse.unquote 
+    HTTPError       = urllib.error.HTTPError
 
 
 from lxml import html   # Debian/Ubuntu: python-lxml
@@ -120,10 +121,10 @@ class HttpBot(object):
         completed = False
         try:
             with open(path, 'wb') as f:
-                for data in iter(lambda: download.read(chunk_size), ''):
+                for data in iter(lambda: download.read(chunk_size), b''):
                     f.write(data)
                     if show:
-                        pbar.update(min([size, pbar.currval + chunk_size]))
+                        pbar.update(min([size, pbar.value + chunk_size]))
                 completed = True
         except KeyboardInterrupt:
             pass
@@ -168,6 +169,6 @@ def filehash(path, hashobj=None, chunk_size=0):
     hashobj = hashobj or hashlib.md5()
     chunk = chunk_size or 32*1024
     with open(path, 'rb') as f:
-        for data in iter(lambda: f.read(chunk), ''):
+        for data in iter(lambda: f.read(chunk), b''):
             hashobj.update(data)
     return hashobj.hexdigest()

--- a/humblebundle.py
+++ b/humblebundle.py
@@ -729,6 +729,8 @@ class HumbleBundle(httpbot.HttpBot):
 
 
 def main(argv=None):
+    if argv == None:
+        argv = sys.argv[1:]
     args, parser = parseargs(argv)
     logging.basicConfig(level=getattr(logging, args.loglevel.upper(), None),
                         format='%(asctime)s\t%(levelname)-8s\t%(message)s')
@@ -1016,7 +1018,6 @@ def parseargs(argv=None):
                         choices=['custom', 'deb', 'apt', 'mojo', 'air', 'steam'],
                         help="Use this method instead of the default"
                             " for (un-)installing a game")
-
     args = parser.parse_args(argv)
     args.debug = args.loglevel=='debug'
     return args, parser

--- a/humblebundle.py
+++ b/humblebundle.py
@@ -1018,6 +1018,7 @@ def parseargs(argv=None):
                         choices=['custom', 'deb', 'apt', 'mojo', 'air', 'steam'],
                         help="Use this method instead of the default"
                             " for (un-)installing a game")
+
     args = parser.parse_args(argv)
     args.debug = args.loglevel=='debug'
     return args, parser


### PR DESCRIPTION
I had not tested the download capability under Python 3 previously.  It turned out this option needed some minor modifications.  With this pull request, I have now gotten the download option working in Python 3.

When called with the trace module, it wasn't passing the argv correctly to the main() function.  I made a minor tweak to work-around this.

I ran into an issue with iterating over binary reads that it would iterate forever since python v3 treats '' and b'' as two different things.  The kept the script from proceeding past the download.

It also seems like Progressbar v2 has no currval but both the python v2 and v3 modules have "value" instead.

Let me know if there is anything you would like see modified in the pull request before merging.
