### PR TITLE
Change deprecated logger.warn() method with logger.warning()

### DIFF
--- a/httpbot.py
+++ b/httpbot.py
@@ -131,7 +131,7 @@ class HttpBot(object):
             if show:
                 pbar.finish()
             if not completed:
-                log.warn("Download aborted")
+                log.warning("Download aborted")
                 if not keep_partial:
                     log.debug("Removing partial file")
                     os.remove(path)
@@ -145,7 +145,7 @@ class HttpBot(object):
                 log.debug("Download MD5 match: %s", md5sum)
                 return path
             else:
-                log.warn("Download MD5 does not match - file is likely corrupt.")
+                log.warning("Download MD5 does not match - file is likely corrupt.")
                 log.debug("Expected and downloaded MD5:\n%s\n%s", md5sum, realhash)
 
     def quote(self, text):

--- a/humblebundle.py
+++ b/humblebundle.py
@@ -176,7 +176,7 @@ class HumbleBundle(httpbot.HttpBot):
                 games = json.load(fp)
             self.games.update(games)
         except (IOError, ValueError) as e:
-            log.warn("Error merging extras: %s", e)
+            log.warning("Error merging extras: %s", e)
 
         # Merge install instructions
         self.gamedata = osp.join(self.datadir, "gamedata.json")
@@ -187,7 +187,7 @@ class HumbleBundle(httpbot.HttpBot):
             for game in self.games:
                 self.games[game].update(games.get(game, {}))
         except (IOError, ValueError) as e:
-            log.warn("Error merging games install data: %s", e)
+            log.warning("Error merging games install data: %s", e)
 
 
     def update(self):
@@ -853,7 +853,7 @@ def clear_auth(appname=None, authfile=None, cookiejar=None):
             log.debug("Removing credentials from keyring")
             keyring.delete_password(appname, appname)
         except AttributeError as e:
-            log.warn("Error removing keyring credentials. Outdated library? (%s)", e)
+            log.warning("Error removing keyring credentials. Outdated library? (%s)", e)
     else:
         authfiles.append(authfile)
 
@@ -891,9 +891,9 @@ def read_config(args, appname=None, authfile=None):
                 try:
                     keyring.delete_password(appname, '')
                 except AttributeError as e:
-                    log.warn("Error deleting old keyring. Outdated library? (%s)", e)
+                    log.warning("Error deleting old keyring. Outdated library? (%s)", e)
             else:
-                log.warn("Credentials not found in keyring. First time usage?")
+                log.warning("Credentials not found in keyring. First time usage?")
         except IOError as e:  # keyring sometimes raises this
             log.error(e)
     else:
@@ -903,7 +903,7 @@ def read_config(args, appname=None, authfile=None):
                 username, password = (fd.read().splitlines() + ['\n'])[:2]
         except IOError as e:
             if e.errno == 2:  # No such file or directory
-                log.warn("Credentials file not found. First time usage?")
+                log.warning("Credentials file not found. First time usage?")
             else:
                 log.error(e)
 


### PR DESCRIPTION
https://bugs.python.org/issue13235

"That's deliberate. The original code (before incorporation into Python)
had warn(), which was kept for backward compatibility. The docs refer to
warning() because that's what everyone is supposed to use. The method
names map to the lower case of the appropriate logging level name."