### PR TITLE
Update gamekeys regex to handle new JSON key list

### DIFF
--- a/humblebundle.py
+++ b/humblebundle.py
@@ -201,7 +201,7 @@ class HumbleBundle(httpbot.HttpBot):
 
         # Get the keys
         log.info("Retrieving keys from '%s/home/keys'", self.url)
-        match = re.search(r'^.*gamekeys\s*=\s*(\[.*\])',
+        match = re.search(r'^.*[\'"]?gamekeys[\'"]?\s*[:=]\s*(\[.*\])',
                           self.get('/home/keys').read().decode('utf-8'),
                           re.MULTILINE)
         if not match:


### PR DESCRIPTION
## Overview
From some quick investigation, it looks like `gamekeys` is in a `script` tag now that looks like this:
```
<script id="user-home-json-data" type="application/json">
  {
    "activePlatform": "windows",
    "gamekeys":  ["somekeys"],
    "hasAdmin": false
  }
</script>
```
I updated the regex to handle this while also preserving the old format (Is that necessary? If not I can update the PR). I did some local testing and was able to make `example.py` work with this change. This should fix #50.

## Testing
Honestly there's probably a simpler way to test this but I haven't written much code in a month and this was the faster way to get the PR out.
```
$ mkdir test-or-whatever
$ cd test-or-whatever
```
### `example.py`
Create this file, filling in the necessary values:
```
from __future__ import print_function
import humblebundle

hb = humblebundle.HumbleBundle(
    'your username',
    'your password',
)

hb.update()
print(hb.games)
```
### `build.sh`
This creates (and runs) the necessary files.
```
#/bin/bash

rm -rf ./Pipfile*
pipenv --python=2
pipenv install -e 'git+https://github.com/thecjharries/humblebundle.git#egg=humblebundle'
sed -i 's@^humble.*@humblebundle = {git = "https://github.com/thecjharries/humblebundle.git", editable = true, ref = "fix-gamekeys-regex"}@' Pipfile
pipenv install
echo '

[scripts]
example = "python example.py"' >> Pipfile
pipenv run example
```
Note that you might have to add `auth` and/or `code` to `example.py` to make things work. You can just run this instead of the entire script after doing that:
```
$ pipenv run example
```