### PR TITLE
Add a working build configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 *.egg-info
 ref/
+dist/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include hooks/*/*.hook
+include installers/*.install
+include installers/*.uninstall
+include extras.json
+include gamedata.json
+include makeinstall

--- a/README.md
+++ b/README.md
@@ -35,28 +35,31 @@ The above can be installed in any modern Debian-like distros (like Ubuntu/Mint) 
 Install
 -------
 
-Just clone the repository and optionally symlink the main script from somewhere in your `$PATH`:
+Clone the repository and install as an editable package:
 
 	cd ~/some/dir
 	git clone https://github.com/MestreLion/humblebundle.git
+	pip install -e humblebundle
 
-	mkdir -p ~/.local/bin
-	ln -s ~/some/dir/humblebundle/humblebundle.py ~/.local/bin/humblebundle
-	echo 'PATH=$HOME/.local/bin:$PATH' >> ~/.profile  # or ~/.bashrc
-
-To use as a python library, also add the repository directory to your `$PYTHONPATH` environment.
-
-(Yes, this project *desperately* needs a `setup.py`!)
-
+This installs both the main script `humblebundle` and the library `humblebundle`.
 
 Uninstall
 ---------
 
-Just delete the directory! And the symlink, if you created it:
+Remove authentication files:
 
+	humblebundle --clear
+
+Uninstall and delete the directory:
+
+	pip uninstall humblebundle-manager
 	rm -rf ~/some/dir/humblebundle
-	rm -f ~/.local/bin/humblebundle
 
+There may be additional files in the config folder, such as `bundles.json` and
+`games.json`, that are downloaded while using the app, as well as downloaded
+files in the cache folder. The default config folder on Unix-like systems is
+`~/.config/humblebundle`, and the default cache folder is
+`~/.cache/humblebundle`
 
 ---
 
@@ -262,14 +265,21 @@ Usage as a library
 ---
 
 
+Building the `humblebundle-manager` package
+-------------------------------------------
+
+Due to an earlier package called `humblebundle`, the package is called `humblebundle-manager`. To build the package:
+
+    pip install build twine
+    python -m build
+    twine check dist/*
+
 Contributing
 ------------
 
 Patches are welcome! Fork, hack, request pull! Here is my current to-do list:
 
 - **Better documentation**: Improve this `README`, document `installers/` usage, custom `hooks/` interface, explain how credentials are used and stored, `gamedata.json` format and usage, config dir structure. And, most important, describe the install mechanics in more detail.
-
-- **Install**: create a decent `setup.py`, possibly uploading to Pypi
 
 - **Classes**: convert the games and bundles dictionaries to classes with attributes and methods. `HumbleBundle.get_game()` would return a `Game` instance, methods `.install()`, `.download()` etc would be there and not on the "main" HumbleBundle class.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,40 @@
+[metadata]
+name = humblebundle-manager
+version = 0.0.1
+description = Manages Humble Bundle games and bundles
+long_description = file: README.md
+long_description_content_type = text/markdown
+classifiers =
+    Development Status :: 4 - Beta
+    License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 2.7
+keywords = humblebundle
+author = Rodrigo Silva
+author_email = linux@rodrigosilva.com
+url = https://github.com/MestreLion/humblebundle
+license = GPLv3+
+license_files = LICENSE.txt
+project_urls =
+    Source Code = https://github.com/MestreLion/humblebundle
+
+[options]
+zip_safe = True
+include_package_data = True
+install_requires =
+    lxml
+    progressbar
+    keyring
+    pyxdg
+    dbus-python; platform_system=='Linux'
+    secretstorage; platform_system=='Linux'
+setup_requires =
+    setuptools >=38.3.0
+py_modules =
+    httpbot
+    humblebundle
+
+[options.entry_points]
+console_scripts =
+    humblebundle = humblebundle:cli

--- a/setup.py
+++ b/setup.py
@@ -1,31 +1,3 @@
-import sys
+from setuptools import setup
 
-from distutils.core import setup
-from setuptools import find_packages
-
-install_requires = [
-    'lxml',
-    'progressbar',
-    'keyring',
-    'pyxdg',
-]
-
-if sys.platform.startswith('linux'):
-    install_requires += [
-        'dbus-python',   # requires libdbus-glib-1-dev
-        'secretstorage',
-    ]
-
-setup(
-    name='humblebundle',
-    version='0.0.0',
-    url='https://github.com/MestreLion/humblebundle',
-    packages=find_packages(exclude=['tests']),
-    setup_requires=['setuptools-git'],
-    install_requires=install_requires,
-    entry_points={
-        'console_scripts': [
-            'humblebundle = humblebundle:cli',
-        ],
-    },
-)
+setup()


### PR DESCRIPTION
* Change the name to `humblebundler-manager`, to avoid conflicting with a previously registered package `humblebundle`.
* Convert `setup.py` to use `setup.cfg`.
* Add `MANIFEST.in` for non-Python hooks, installers, and JSON
* Update the `README.md` with new install / uninstall instructions, and add build instructions.